### PR TITLE
Fix for Authorization::Reader::DSLFileNotFoundError

### DIFF
--- a/lib/declarative_authorization/authorization.rb
+++ b/lib/declarative_authorization/authorization.rb
@@ -20,7 +20,7 @@ module Authorization
   # The exception is raised to ensure that the entire rule is invalidated.
   class NilAttributeValueError < AuthorizationError; end
   
-  AUTH_DSL_FILES = [Pathname.new(Rails.root || '').join("config", "authorization_rules.rb").to_s] unless defined? AUTH_DSL_FILES
+  AUTH_DSL_FILES = [File.expand_path("./config/authorization_rules.rb", Rails.root)] unless defined? AUTH_DSL_FILES
   
   # Controller-independent method for retrieving the current user.
   # Needed for model security where the current controller is not available.


### PR DESCRIPTION
We are using DA internally with a rails 3 app. This app has a lot of ajax calls and everything needs to be authorized. In development, but not in production, we were seeing this error:
Authorization::Reader::DSLFileNotFoundError in MainController#index 
Error reading authorization rules file with path 
'/config/authorization_rules.rb'!  Please ensure it exists and that it 
is accessible.

Looking deeper I found that the dsl file was being set:
Pathname.new(Rails.root || '').join("config", "authorization_rules.rb").to_s

It looks like Rails.root isn't being populated between ajax calls. That's just a guess but doing an File.expand_path to get the full pathname seemed to work.
