### PR TITLE
has_any_role? implementation

### DIFF
--- a/lib/declarative_authorization/helper.rb
+++ b/lib/declarative_authorization/helper.rb
@@ -56,5 +56,9 @@ module Authorization
     def has_role_with_hierarchy?(*roles, &block)
       controller.has_role_with_hierarchy?(*roles, &block)
     end
+    
+    def has_any_role?(*roles,&block)
+      controller.has_any_role?(*roles,&block)
+    end
   end
 end

--- a/lib/declarative_authorization/helper.rb
+++ b/lib/declarative_authorization/helper.rb
@@ -60,5 +60,9 @@ module Authorization
     def has_any_role?(*roles,&block)
       controller.has_any_role?(*roles,&block)
     end
+    
+    def has_any_role_with_hierarchy?(*roles, &block)
+      controller.has_any_role_with_hierarchy?(*roles, &block)
+    end
   end
 end

--- a/lib/declarative_authorization/in_controller.rb
+++ b/lib/declarative_authorization/in_controller.rb
@@ -107,6 +107,15 @@ module Authorization
       result
     end
     
+    # As has_any_role? except checks all roles included in the role hierarchy
+    def has_any_role_with_hierarchy?(*roles, &block)
+      user_roles = authorization_engine.roles_with_hierarchy_for(current_user)
+      result = roles.any? do |role|
+        user_roles.include?(role)
+      end
+      yield if result and block_given?
+      result
+    end
     
     protected
     def filter_access_filter # :nodoc:

--- a/lib/declarative_authorization/in_controller.rb
+++ b/lib/declarative_authorization/in_controller.rb
@@ -86,6 +86,17 @@ module Authorization
       result
     end
     
+    # Intended to be used where you want to allow users with any single listed role to view 
+    # the content in question
+    def has_any_role?(*roles,&block)
+      user_roles = authorization_engine.roles_for(current_user)
+      result = roles.any? do |role|
+        user_roles.include?(role)
+      end
+      yield if result and block_given?
+      result
+    end
+    
     # As has_role? except checks all roles included in the role hierarchy
     def has_role_with_hierarchy?(*roles, &block)
       user_roles = authorization_engine.roles_with_hierarchy_for(current_user)

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -200,8 +200,48 @@ class HelperTest < ActionController::TestCase
       block_evaled = true
     end
     assert !block_evaled
-
   end
   
-  
+  def test_has_any_role_with_hierarchy
+    reader = Authorization::Reader::DSLReader.new
+    reader.parse %{
+      authorization do
+        role :test_role do
+          has_permission_on :mocks, :to => :show
+        end
+        role :other_role do
+          has_permission_on :another_mocks, :to => :show
+        end
+
+        role :root do
+          includes :test_role
+        end
+      end
+    }    
+    
+    user = MockUser.new(:root)
+    request!(user, :action, reader)
+    
+    assert has_any_role_with_hierarchy?(:test_role)
+    assert !has_any_role_with_hierarchy?(:other_role)
+    assert has_any_role_with_hierarchy?(:test_role,:other_role)
+
+    block_evaled = false
+    has_any_role_with_hierarchy?(:test_role) do
+      block_evaled = true
+    end
+    assert block_evaled
+    
+    block_evaled = false
+    has_any_role_with_hierarchy?(:test_role2) do
+      block_evaled = true
+    end
+    assert !block_evaled
+    
+    block_evaled = false
+    has_any_role_with_hierarchy?(:test_role,:test_role2) do
+      block_evaled = true
+    end
+    assert block_evaled
+  end
 end

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -113,7 +113,42 @@ class HelperTest < ActionController::TestCase
     end
     assert !block_evaled
   end
-
+  
+  def test_has_any_role
+    reader = Authorization::Reader::DSLReader.new
+    reader.parse %{
+      authorization do
+        role :test_role do
+          has_permission_on :mocks, :to => :show
+        end
+      end
+    }
+    user = MockUser.new(:test_role)
+    request!(user, :action, reader)
+    
+    assert has_any_role?(:test_role)
+    assert !has_any_role?(:test_role2)
+    assert has_any_role?(:test_role, :test_role2)
+    
+    block_evaled = false
+    has_any_role?(:test_role) do
+      block_evaled = true
+    end
+    assert block_evaled
+    
+    block_evaled = false
+    has_any_role?(:test_role2) do
+      block_evaled = true
+    end
+    assert !block_evaled
+    
+    block_evaled = false
+    has_any_role?(:test_role,:test_role2) do
+      block_evaled = true
+    end
+    assert block_evaled
+  end
+  
   def test_has_role_with_guest_user
     reader = Authorization::Reader::DSLReader.new
     reader.parse %{


### PR DESCRIPTION
As discussed on the mailing list I implemented `has_any_role?` and `has_any_role_with_heirarchy?` to allow users to have any one of the roles passed instead of requiring all of them.
