### PR TITLE
performance improvements

### DIFF
--- a/lib/declarative_authorization/authorization.rb
+++ b/lib/declarative_authorization/authorization.rb
@@ -191,15 +191,15 @@ module Authorization
       end
     end
     
-    # Calls permit! but rescues the AuthorizationException and returns false
-    # instead.  If no exception is raised, permit? returns true and yields
-    # to the optional block.
-    def permit? (privilege, options = {}, &block) # :yields:
-      permit!(privilege, options)
-      yield if block_given?
-      true
-    rescue NotAuthorized
-      false
+    # Calls permit! but doesn't raise authorization errors. If no exception is
+    # raised, permit? returns true and yields  to the optional block.
+    def permit? (privilege, options = {}) # :yields:
+      if permit!(privilege, options.merge(:bang=> false))
+        yield if block_given?
+        true
+      else
+        false
+      end
     end
     
     # Returns the obligations to be met by the current user for the given 

--- a/test/authorization_test.rb
+++ b/test/authorization_test.rb
@@ -1095,10 +1095,10 @@ class AuthorizationTest < Test::Unit::TestCase
 
     engine = Authorization::Engine.new(reader)
     cloned_engine = engine.clone
-    assert_not_equal engine.auth_rules[0].contexts.object_id,
-        cloned_engine.auth_rules[0].contexts.object_id
-    assert_not_equal engine.auth_rules[0].attributes[0].send(:instance_variable_get, :@conditions_hash)[:attr].object_id,
-        cloned_engine.auth_rules[0].attributes[0].send(:instance_variable_get, :@conditions_hash)[:attr].object_id
+    assert_not_equal engine.auth_rules.first.contexts.object_id,
+        cloned_engine.auth_rules.first.contexts.object_id
+    assert_not_equal engine.auth_rules.first.attributes.first.send(:instance_variable_get, :@conditions_hash)[:attr].object_id,
+        cloned_engine.auth_rules.first.attributes.first.send(:instance_variable_get, :@conditions_hash)[:attr].object_id
   end
 end
 


### PR DESCRIPTION
These three commits should make the runtime of simple permitted_to? calls about 80% faster.

This is done by
- Storing AuthorizationRules in an AuthorizationRuleSet, which will put AuthorizationRules in a hash based on their context for a fast lookup on `matching_auth_rules` calls.
- Avoiding use of exceptions in `permitted_to?` calls by adding a `:bang` option to `Authorization::Engine.permit!` (default true), which, when set to false, will return false instead of raising and rescuing exceptions.
- Refactoring AuthorizationInController's `permitted_to?` and `permitted_to!` to avoid splats and explicit blocks (minute difference)

Here is the performance graph for permitted_to? calls from before any changes were made (current HEAD)
![before](http://i.imgur.com/hYjTO.png)

After the first commit (hash lookups)
![after 5303bf7](http://i.imgur.com/2PCom.png)

After final commit (don't raise/rescue exceptions)
![after 792b155](http://i.imgur.com/xy089.png)
