### PR TITLE
Don't destructively modify SafeBuffers

### DIFF
--- a/app/helpers/authorization_rules_helper.rb
+++ b/app/helpers/authorization_rules_helper.rb
@@ -13,7 +13,7 @@ module AuthorizationRulesHelper
     }
     regexps.each do |name, res|
       res.each do |re|
-        rules.gsub!(
+        rules = rules.gsub(
           re.is_a?(String) ? Regexp.new("(^|[^:])\\b(#{Regexp.escape(re)})\\b") :
              (re.is_a?(Symbol) ? Regexp.new("()(:#{Regexp.escape(re.to_s)})\\b") : re), 
           "\\1<span class=\"#{name}\">\\2</span>")


### PR DESCRIPTION
When running under Rails 3.0.9 the syntax_highlight helper causes a "cannot modify SafeBuffer" error.. 

This patch fixes the issue.. (lovingly adapted from https://github.com/nex3/haml/commit/fc5a5cb21de15a7c2fde83d4e06a021b2d86c4f1 )
