### PR TITLE
auto Rule reloading no longer works in development

### DIFF
--- a/lib/declarative_authorization/authorization.rb
+++ b/lib/declarative_authorization/authorization.rb
@@ -277,12 +277,23 @@ module Authorization
     def roles_with_hierarchy_for(user)
       flatten_roles(roles_for(user))
     end
-    
+
+    def self.development_reload?
+      if Rails.env.development?
+        mod_time = AUTH_DSL_FILES.map { |m| File.mtime(m) }.flatten.max
+        @@auth_dsl_last_modified ||= mod_time
+        if mod_time > @@auth_dsl_last_modified
+          @@auth_dsl_last_modified = mod_time
+          return true
+        end
+      end
+    end
+
     # Returns an instance of Engine, which is created if there isn't one
     # yet.  If +dsl_file+ is given, it is passed on to Engine.new and 
     # a new instance is always created.
     def self.instance (dsl_file = nil)
-      if dsl_file
+      if dsl_file or development_reload?
         @@instance = new(dsl_file)
       else
         @@instance ||= new


### PR DESCRIPTION
In previous version (0.5.3), the auth rules config would be reloaded with each request in development mode allowing for tweaking of the rules file without restarting the server..  However with 0.5.5 this no longer happens.  It seems to be caused by commit fb37826 on lines 274/275 (self.initialize) (current master line 283).  Basically the "or in development" check was removed.   Is there a better way of implementing this now?  Or was this an accidental removal?

Ideally I would like it to ONLY reload the files in AUTH_DSL_FILES _if_ they have changed instead of every request.
