### PR TITLE
implement additional_no_authorization_check option for filter_resource_access

### DIFF
--- a/lib/declarative_authorization/in_controller.rb
+++ b/lib/declarative_authorization/in_controller.rb
@@ -472,6 +472,7 @@ module Authorization
           #:new_method => nil,                 # only symbol method name
           #:load_method => nil,                # only symbol method name
           :no_attribute_check => nil,
+          :additional_no_attribute_check => nil,
           :context    => nil,
           :nested_in  => nil,
         }.merge(options)
@@ -484,6 +485,7 @@ module Authorization
             actions_from_option(options[:additional_collection]))
 
         options[:no_attribute_check] ||= collections.keys unless options[:nested_in]
+        options[:no_attribute_check].concat([*options[:additional_no_attribute_check]]) if options[:additional_no_attribute_check]
 
         unless options[:nested_in].blank?
           load_parent_method = :"load_#{options[:nested_in].to_s.singularize}"


### PR DESCRIPTION
This simple patch add in a :additional_no_attribute_check option for filter_resource_access.

I've been bitten by the fact that the existing :no_attribute_check replaces instead of adds to the collection entries, so am fixing it :)
