### PR TITLE
Delete intrusive temporary object from proxy object

### DIFF
--- a/lib/declarative_authorization/authorization.rb
+++ b/lib/declarative_authorization/authorization.rb
@@ -155,7 +155,7 @@ module Authorization
       privilege = privilege.is_a?( Array ) ?
                   privilege.flatten.collect { |priv| priv.to_sym } :
                   privilege.to_sym
-      
+      begin
       #
       # If the object responds to :proxy_reflection, we're probably working with
       # an association proxy.  Use 'new' to leverage ActiveRecord's builder
@@ -164,7 +164,8 @@ module Authorization
       # Example: permit!( :edit, :object => user.posts )
       #
       if Authorization.is_a_association_proxy?(options[:object]) && options[:object].respond_to?(:new)
-        options[:object] = options[:object].new
+        proxy = options[:object]
+        temporary_build = options[:object] = options[:object].new
       end
       
       options[:context] ||= options[:object] && (
@@ -197,6 +198,11 @@ module Authorization
         end
       else
         false
+      end
+      ensure
+        if temporary_build
+          proxy.delete temporary_build
+        end
       end
     end
     

--- a/lib/declarative_authorization/authorization.rb
+++ b/lib/declarative_authorization/authorization.rb
@@ -165,7 +165,11 @@ module Authorization
       #
       if Authorization.is_a_association_proxy?(options[:object]) && options[:object].respond_to?(:new)
         proxy = options[:object]
-        temporary_build = options[:object] = options[:object].new
+        if options[:reverse_relation]
+          temporary_build = options[:object] = options[:object].new(options[:reverse_relation] => [proxy.proxy_association.owner])
+        else
+          temporary_build = options[:object] = options[:object].new
+        end
       end
       
       options[:context] ||= options[:object] && (


### PR DESCRIPTION
When we create an object in this proxy object, it persists on into the rest of the view, which can cause unintended problems. 

I think wrapping this in a begin/ensure means the return value is still whatever the function returned, but we can restore the proxy object back to what is was before.
