### PR TITLE
under ruby 1.9.2, .name returns nil for anonymous classes

### DIFF
--- a/lib/declarative_authorization/maintenance.rb
+++ b/lib/declarative_authorization/maintenance.rb
@@ -60,9 +60,10 @@ module Authorization
           end
         rescue Errno::ENOENT
         end
-        controllers = []
-        ObjectSpace.each_object(Class) do |obj|
-          controllers << obj if obj.ancestors.include?(ActionController::Base) and obj != ActionController::Base and obj.name.demodulize != 'ApplicationController'
+        controllers = ObjectSpace.each_object(Class).select do |obj|
+          obj.ancestors.include?(ActionController::Base) &&
+            obj != ActionController::Base &&
+            (!obj.name || obj.name.demodulize != 'ApplicationController')
         end
 
         controllers.inject({}) do |memo, controller|


### PR DESCRIPTION
Inside Authorization::Usage::Disables.usages_by_controller is the line

```
controllers << obj if obj.ancestors.include?(ActionController::Base) and obj != ActionController::Base and obj.name.demodulize != 'ApplicationController'
```

Under 1.9.2 and above this raises an exception when there it encounters an anonymous class, where .name returns nil (1.8.7 returns '').

This fix makes all rails 3 tests pass on 1.9.2 and 1.9.3. http://travis-ci.org/#!/jhawthorn/declarative_authorization/builds/2041629
