### PR TITLE
Avoid adding temporary object to association proxy

### DIFF
--- a/lib/declarative_authorization/authorization.rb
+++ b/lib/declarative_authorization/authorization.rb
@@ -164,7 +164,7 @@ module Authorization
       # Example: permit!( :edit, :object => user.posts )
       #
       if Authorization.is_a_association_proxy?(options[:object]) && options[:object].respond_to?(:new)
-        options[:object] = options[:object].new
+        options[:object] = (Rails.version < "3.0" ? options[:object] : options[:object].scoped).new
       end
       
       options[:context] ||= options[:object] && (

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -1801,6 +1801,7 @@ class ModelTest < Test::Unit::TestCase
     test_model = TestModel.create(:content => "content")
     assert engine.permit?(:read, :object => test_model.test_attrs,
                           :user => MockUser.new(:test_role))
+    assert test_model.test_attrs.empty?
     assert !engine.permit?(:read, :object => TestAttr.new,
                           :user => MockUser.new(:test_role))
     TestModel.delete_all


### PR DESCRIPTION
This is an alternative commit to pull request #147, and there is some discussion of this approach in that request.

This prevents the temporary object used for testing permissions from being added to the association proxy by calling .scoped.new instead of simply .new. This should still fill in the appropriate values.

With .new

```
>> u = User.first
User Load (0.4ms)  SELECT `users`.* FROM `users` LIMIT 1
=> #<User id: 1,...
>> u.comments.new
=> #<Comment id: nil, user_id: 1, body: nil, created_at: nil, updated_at: nil>
=> #<User id: 1, ...
>> u.comments
=> [#<Comment id: nil, user_id: 1, body: nil, created_at: nil, updated_at: nil>]
```

vs .scoped.new

```
>> u = User.first
User Load (0.4ms)  SELECT `users`.* FROM `users` LIMIT 1
=> #<User id: 1,...
>> u.comments.scoped.new
=> #<Comment id: nil, user_id: 1, body: nil, created_at: nil, updated_at: nil>
=> #<User id: 1, ...
>> u.comments
=> []
```
