### PR TITLE
fix for broken display of /authorization_usages

### DIFF
--- a/app/views/authorization_rules/_show_graph.erb
+++ b/app/views/authorization_rules/_show_graph.erb
@@ -40,5 +40,5 @@
 <% end %>
 <div id="graph-container" style="display:none">
 <%= link_to_function "Hide", "$('graph-container').hide()", :class => 'important' %><br/>
-<object id="graph" data="" type="image/svg+xml" style="max-width:100%;margin-top: 0.5em"/>
+<object id="graph" data="" type="image/svg+xml" style="max-width:100%;margin-top: 0.5em"></object>
 </div>


### PR DESCRIPTION
The object tag breaks the display of the usages-table. Fixed that one.
