### PR TITLE
Another fix for stray objects in Rails 3

### DIFF
--- a/lib/declarative_authorization/in_controller.rb
+++ b/lib/declarative_authorization/in_controller.rb
@@ -163,7 +163,7 @@ module Authorization
            instance_variable_get(:"@#{parent_context_without_namespace.to_s.singularize}").send(context_without_namespace.to_sym) :
            context_without_namespace.to_s.classify.constantize
       instance_var = :"@#{context_without_namespace.to_s.singularize}"
-      instance_variable_set(instance_var, model_or_proxy.new)
+      instance_variable_set(instance_var, (model_or_proxy.respond_to?(:scoped) ? model_or_proxy.scoped : model_or_proxy).new)
     end
 
     def options_for_permit (object_or_sym = nil, options = {}, bang = true)


### PR DESCRIPTION
Greetings. I saw the previous commit that fixed a stray object issue, but I was still encountering stray objects in my Rails 3.2 associations when doing filter_resource_access with a :nested_in. This change alleviates the problem.

Before my change, all tests were passing for me except one, and after my change, that is still the case. I'm not sure where in the tests to add something to test this fix, however. Suggestions welcome.
