### PR TITLE
removes harmful OR (1=1)

### DIFF
--- a/lib/declarative_authorization/obligation_scope.rb
+++ b/lib/declarative_authorization/obligation_scope.rb
@@ -283,8 +283,8 @@ module Authorization
             end
           end
         end
-        obligation_conds << "1=1" if obligation_conds.empty?
-        conds << "(#{obligation_conds.join(' AND ')})"
+        obligation_conds << "1=1" if (obligation_conds.empty? && conds.empty?)
+        conds << "(#{obligation_conds.join(' AND ')})" unless obligation_conds.empty?
       end
       (delete_paths - used_paths).each {|path| reflections.delete(path)}
 


### PR DESCRIPTION
This fixes a problem in which sql like this can be generated:

SELECT DISTINCT ON ("screening_projects".id) "screening_projects".id, screening_projects.display_order AS alias_0 
FROM "screening_projects" 
LEFT OUTER JOIN "screening_project_roles" ON ("screening_projects"."id" = "screening_project_roles"."screening_project_id") 
LEFT OUTER JOIN "roles" ON ("roles"."id" = "screening_project_roles"."role_id") 
WHERE (("roles"."id" IN (3,4,5)) OR (1=1))

(note the extra 1=1 that emasculates the "id in..." subquery)
in response to an if_attribute rule like this:

if_attribute :roles => intersects_with {user.roles}
 
