### PR TITLE
Let attribute checks work with PostgreSQL schemas

### DIFF
--- a/lib/declarative_authorization/obligation_scope.rb
+++ b/lib/declarative_authorization/obligation_scope.rb
@@ -263,7 +263,7 @@ module Authorization
               attribute_table_alias = table_alias
               used_paths << path
             end
-            bindvar = "#{attribute_table_alias}__#{attribute_name}_#{obligation_index}".to_sym
+            bindvar = "#{attribute_table_alias.gsub(".", "_")}__#{attribute_name}_#{obligation_index}".to_sym
 
             sql_attribute = "#{parent_model.connection.quote_table_name(attribute_table_alias)}." +
                 "#{parent_model.connection.quote_table_name(attribute_name)}"


### PR DESCRIPTION
When working with PostgreSQL, there are some gems that allow
ActiveRecord models to work with multiple schemas. This practice is
common for multi-tenant applications where one would want to separate
client-specific information within their own schema.

The SQL syntax for accessing a different schema in a query uses dot
notation.

``` sql
SELECT * FROM myschema.mytable WHERE myschema.mytable.mycolumn = 1;
```

However, having ActiveRecord append the schema name to tables in all
queries breaks attribute checks in declarative auth.

The attribute check code uses symbol bind variables for sanitation and
passes them into ActiveRecord through finder_options[:conditions]. It
would commonly look something like this:

``` ruby
[
  "(\"clients\".\"assigned_user_id\" = :clients__assigned_user_id_0)",
  {:clients__assigned_user_id_0=>1}
]
```

However when using PostgreSQL schemas, the table name from the
ActiveRecord model comes back as `public.clients` resulting in the
conditions array looking like this:

``` ruby
[
  "(\"public\".\"clients\".\"assigned_user_id\" = :public.clients__assigned_user_id_0)",
  {:"public.clients__assigned_user_id_0"=>1}
]
```

This causes ActiveRecord to not match up the bind variables with the SQL
snippet resulting in a PostgrSQL query error.

To fix this, I use `gsub` to change the period into an underscore when
building the `bindvar` variable. With this change, I get a conditions
array that ActiveRecord will parse properly.

``` ruby
[
  "(\"public\".\"clients\".\"assigned_user_id\" = :public_clients__assigned_user_id_0)",
  {:public_clients__assigned_user_id_0=>1}
]
```
