### PR TITLE
Add license to gemspec

### DIFF
--- a/declarative_authorization.gemspec
+++ b/declarative_authorization.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.has_rdoc = true
   s.extra_rdoc_files = ['README.rdoc', 'CHANGELOG']
   s.homepage = %q{http://github.com/stffn/declarative_authorization}
+  s.license = 'MIT'
 
   #s.add_dependency('rails', '>= 2.1.0')
 end


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.
