### PR TITLE
Add latest Rails, test-unit, and lock ruby_parser

### DIFF
--- a/declarative_authorization.gemspec
+++ b/declarative_authorization.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |s|
   s.has_rdoc = true
   s.extra_rdoc_files = ['README.rdoc', 'CHANGELOG']
   s.homepage = %q{http://github.com/stffn/declarative_authorization}
+  s.add_development_dependency('test-unit')
+  s.add_development_dependency('ruby_parser', '~> 3.6.0')
 
   #s.add_dependency('rails', '>= 2.1.0')
 end

--- a/gemfiles/3.0.gemfile
+++ b/gemfiles/3.0.gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 3.0.0'
 gem 'sqlite3'
-gem 'ruby_parser'
 gem 'rdoc'
 gemspec :path => '..'
 

--- a/gemfiles/3.1.gemfile
+++ b/gemfiles/3.1.gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 3.1.0'
 gem 'sqlite3'
-gem 'ruby_parser'
 gem 'rdoc'
 gemspec :path => '..'
 

--- a/gemfiles/3.2.gemfile
+++ b/gemfiles/3.2.gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 3.2.0'
 gem 'sqlite3'
-gem 'ruby_parser'
 gem 'rdoc'
 gemspec :path => '..'
 

--- a/gemfiles/4.0.gemfile
+++ b/gemfiles/4.0.gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 4.0.0'
 gem 'sqlite3'
-gem 'ruby_parser'
 gem 'rdoc'
 gemspec :path => '..'
 

--- a/gemfiles/4.1.gemfile
+++ b/gemfiles/4.1.gemfile
@@ -2,6 +2,5 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 4.1.0'
 gem 'sqlite3'
-gem 'ruby_parser'
 gem 'rdoc'
 gemspec :path => '..'

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -1,8 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 2.3.0'
+gem 'rails', '~> 4.2.0'
 gem 'sqlite3'
 gem 'rdoc'
-gem 'json'
 gemspec :path => '..'
-


### PR DESCRIPTION
- Add support for testing Rails 4.2 development
- `test-unit` isn't provided by Ruby anymore, so add that to development dependencies.
- Lock `ruby_parser` to a version that's capable of being used for development and move to development dependencies.
