### PR TITLE
Do not put a space between a method name and the opening parenthesis

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require 'rdoc/task'
 desc 'Default: run unit tests against all versions.'
 task :default => 'bundles:test'
 
-def run_for_bundles cmd
+def run_for_bundles(cmd)
   Dir['gemfiles/*.gemfile'].each do |gemfile|
     puts "\n#{gemfile}: #{cmd}"
     ENV['BUNDLE_GEMFILE'] = gemfile

--- a/app/controllers/authorization_rules_controller.rb
+++ b/app/controllers/authorization_rules_controller.rb
@@ -108,7 +108,7 @@ class AuthorizationRulesController < ApplicationController
   end
 
   private
-  def auth_to_dot (options = {})
+  def auth_to_dot(options = {})
     options = {
       :effective_role_privs => true,
       :privilege_hierarchy => false,
@@ -198,7 +198,7 @@ class AuthorizationRulesController < ApplicationController
     render_to_string :template => 'authorization_rules/graph.dot.erb', :layout => false
   end
 
-  def replay_changes (engine, users, changes)
+  def replay_changes(engine, users, changes)
     changes.inject({}) do |memo, info|
       case info[0]
       when :add_privilege, :add_role
@@ -212,7 +212,7 @@ class AuthorizationRulesController < ApplicationController
     end
   end
   
-  def dot_to_svg (dot_data)
+  def dot_to_svg(dot_data)
     gv = IO.popen("#{Authorization.dot_path} -q -Tsvg", "w+")
     gv.puts dot_data
     gv.close_write
@@ -235,7 +235,7 @@ class AuthorizationRulesController < ApplicationController
     }
   end
 
-  def deserialize_changes (changes)
+  def deserialize_changes(changes)
     if changes
       changes.split(';').collect do |info|
         info.split(',').collect do |info_part|
@@ -245,7 +245,7 @@ class AuthorizationRulesController < ApplicationController
     end
   end
 
-  def find_user_by_id (id)
+  def find_user_by_id(id)
     User.find(id)
   end
   def find_all_users

--- a/app/helpers/authorization_rules_helper.rb
+++ b/app/helpers/authorization_rules_helper.rb
@@ -1,5 +1,5 @@
 module AuthorizationRulesHelper
-  def syntax_highlight (rules)
+  def syntax_highlight(rules)
     regexps = {
       :constant => [/(:)(\w+)/], 
       :proc => ['role', 'authorization', 'privileges'],
@@ -22,7 +22,7 @@ module AuthorizationRulesHelper
     rules
   end
 
-  def policy_analysis_hints (marked_up, policy_data)
+  def policy_analysis_hints(marked_up, policy_data)
     analyzer = Authorization::DevelopmentSupport::Analyzer.new(controller.authorization_engine)
     analyzer.analyze(policy_data)
     marked_up_by_line = marked_up.split("\n")
@@ -39,7 +39,7 @@ module AuthorizationRulesHelper
     (marked_up_by_line * "\n").html_safe
   end
 
-  def link_to_graph (title, options = {})
+  def link_to_graph(title, options = {})
     type = options[:type] || ''
     link_to_function title, "$$('object')[0].data = '#{url_for :action => 'index', :format => 'svg', :type => type}'"
   end
@@ -53,7 +53,7 @@ module AuthorizationRulesHelper
   #  link_to("XACML export", :action => 'index', :format => 'xacml')
   end
   
-  def role_color (role, fill = false)
+  def role_color(role, fill = false)
     if @has_changes
       if has_changed(:add_role, role)
         fill ? '#ddffdd' : '#000000'
@@ -74,17 +74,17 @@ module AuthorizationRulesHelper
     end
   end
   
-  def role_fill_color (role)
+  def role_fill_color(role)
     role_color(role, true)
   end
 
-  def privilege_color (privilege, context, role)
+  def privilege_color(privilege, context, role)
     has_changed(:add_privilege, privilege, context, role) ? '#00dd00' :
         (has_changed(:remove_privilege, privilege, context, role) ? '#dd0000' :
           role_color(role))
   end
 
-  def human_privilege (privilege)
+  def human_privilege(privilege)
     begin
       I18n.t(privilege, :scope => [:declarative_authorization, :privilege], :raise => true)
     rescue
@@ -92,7 +92,7 @@ module AuthorizationRulesHelper
     end
   end
 
-  def human_context (context)
+  def human_context(context)
     begin
       context.to_s.classify.constantize.human_name
     rescue
@@ -100,7 +100,7 @@ module AuthorizationRulesHelper
     end
   end
 
-  def human_privilege_context (privilege, context)
+  def human_privilege_context(privilege, context)
     human = [human_privilege(privilege), human_context(context)]
     begin
       unless I18n.t(:verb_in_front_of_object, :scope => :declarative_authorization, :raise => true)
@@ -111,11 +111,11 @@ module AuthorizationRulesHelper
     human * " "
   end
 
-  def human_role (role)
+  def human_role(role)
     Authorization::Engine.instance.title_for(role) or role.to_s
   end
 
-  def describe_step (step, options = {})
+  def describe_step(step, options = {})
     options = {:with_removal => false}.merge(options)
 
     case step[0]
@@ -147,14 +147,14 @@ module AuthorizationRulesHelper
                         "Don't suggest this action.", options)
   end
 
-  def prohibit_link (step, text, title, options)
+  def prohibit_link(step, text, title, options)
     options[:with_removal] ?
           link_to_function("[x]", "prohibit_action('#{serialize_action(step)}', '#{text}')",
                     :class => 'prohibit', :title => title) :
           ''
   end
   
-  def readable_step_info (info)
+  def readable_step_info(info)
     case info
     when Symbol   then info.inspect
     when User     then info.login
@@ -162,29 +162,29 @@ module AuthorizationRulesHelper
     end
   end
 
-  def serialize_changes (approach)
+  def serialize_changes(approach)
     changes = approach.changes.collect {|step| step.to_a.first.is_a?(Enumerable) ? step.to_a : [step.to_a]}
     changes.collect {|multi_step| multi_step.collect {|step| serialize_action(step) }}.flatten * ';'
   end
 
-  def serialize_action (step)
+  def serialize_action(step)
     step.collect {|info| readable_step_info(info) } * ','
   end
 
-  def serialize_relevant_roles (approach)
-    {:filter_roles => (Authorization::DevelopmentSupport::AnalyzerEngine.relevant_roles(approach.engine, approach.users).
+  def serialize_relevant_roles(approach)
+    {:filter_roles =>(Authorization::DevelopmentSupport::AnalyzerEngine.relevant_roles(approach.engine, approach.users).
         map(&:to_sym) + [:new_role_for_change_analyzer]).uniq}.to_param
   end
 
-  def has_changed (*args)
+  def has_changed(*args)
     @changes && @changes[args[0]] && @changes[args[0]].include?(args[1..-1])
   end
 
-  def affected_users_count (approach)
+  def affected_users_count(approach)
     @affected_users[approach]
   end
 
-  def auth_usage_info_classes (auth_info)
+  def auth_usage_info_classes(auth_info)
     classes = []
     if auth_info[:controller_permissions]
       if auth_info[:controller_permissions][0]
@@ -199,7 +199,7 @@ module AuthorizationRulesHelper
     classes * " "
   end
 
-  def auth_usage_info_title (auth_info)
+  def auth_usage_info_title(auth_info)
     titles = []
     if auth_usage_info_classes(auth_info) =~ /unprotected/
       titles << "No filter_access_to call protects this action"

--- a/lib/declarative_authorization/authorization.rb
+++ b/lib/declarative_authorization/authorization.rb
@@ -34,7 +34,7 @@ module Authorization
   end
   
   # For use in test cases only
-  def self.ignore_access_control (state = nil) # :nodoc:
+  def self.ignore_access_control(state = nil) # :nodoc:
     Thread.current["ignore_access_control"] = state unless state.nil?
     Thread.current["ignore_access_control"] || false
   end
@@ -48,7 +48,7 @@ module Authorization
     @@dot_path
   end
 
-  def self.dot_path= (path)
+  def self.dot_path=(path)
     @@dot_path = path
   end
   
@@ -57,11 +57,11 @@ module Authorization
     @@default_role
   end
 
-  def self.default_role= (role)
+  def self.default_role=(role)
     @@default_role = role.to_sym
   end
 
-  def self.is_a_association_proxy? (object)
+  def self.is_a_association_proxy?(object)
     if Rails.version < "3.2"
       object.respond_to?(:proxy_reflection)
     else
@@ -84,12 +84,12 @@ module Authorization
     # If +reader+ is not given, a new one is created with the default
     # authorization configuration of +AUTH_DSL_FILES+.  If given, may be either
     # a Reader object or a path to a configuration file.
-    def initialize (reader = nil)
+    def initialize(reader = nil)
       #@auth_rules = AuthorizationRuleSet.new reader.auth_rules_reader.auth_rules
       @reader = Reader::DSLReader.factory(reader || AUTH_DSL_FILES)
     end
 
-    def initialize_copy (from) # :nodoc:
+    def initialize_copy(from) # :nodoc:
       @reader = from.reader.clone
     end
 
@@ -142,7 +142,7 @@ module Authorization
     #   Should NotAuthorized exceptions be raised
     #   Defaults to true.
     #
-    def permit! (privilege, options = {})
+    def permit!(privilege, options = {})
       return true if Authorization.ignore_access_control
       options = {
         :object => nil,
@@ -202,7 +202,7 @@ module Authorization
     
     # Calls permit! but doesn't raise authorization errors. If no exception is
     # raised, permit? returns true and yields  to the optional block.
-    def permit? (privilege, options = {}) # :yields:
+    def permit?(privilege, options = {}) # :yields:
       if permit!(privilege, options.merge(:bang=> false))
         yield if block_given?
         true
@@ -227,7 +227,7 @@ module Authorization
     # [:+context+]  See permit!
     # [:+user+]  See permit!
     # 
-    def obligations (privilege, options = {})
+    def obligations(privilege, options = {})
       options = {:context => nil}.merge(options)
       user, roles, privileges = user_roles_privleges_from_options(privilege, options)
 
@@ -244,19 +244,19 @@ module Authorization
     # Returns the description for the given role.  The description may be
     # specified with the authorization rules.  Returns +nil+ if none was
     # given.
-    def description_for (role)
+    def description_for(role)
       role_descriptions[role]
     end
     
     # Returns the title for the given role.  The title may be
     # specified with the authorization rules.  Returns +nil+ if none was
     # given.
-    def title_for (role)
+    def title_for(role)
       role_titles[role]
     end
 
     # Returns the role symbols of the given user.
-    def roles_for (user)
+    def roles_for(user)
       user ||= Authorization.current_user
       raise AuthorizationUsageError, "User object doesn't respond to roles (#{user.inspect})" \
         if !user.respond_to?(:role_symbols) and !user.respond_to?(:roles)
@@ -292,7 +292,7 @@ module Authorization
     # Returns an instance of Engine, which is created if there isn't one
     # yet.  If +dsl_file+ is given, it is passed on to Engine.new and 
     # a new instance is always created.
-    def self.instance (dsl_file = nil)
+    def self.instance(dsl_file = nil)
       if dsl_file or development_reload?
         @@instance = new(dsl_file)
       else
@@ -302,7 +302,7 @@ module Authorization
     
     class AttributeValidator # :nodoc:
       attr_reader :user, :object, :engine, :context, :privilege
-      def initialize (engine, user, object = nil, privilege = nil, context = nil)
+      def initialize(engine, user, object = nil, privilege = nil, context = nil)
         @engine = engine
         @user = user
         @object = object
@@ -310,7 +310,7 @@ module Authorization
         @context = context
       end
       
-      def evaluate (value_block)
+      def evaluate(value_block)
         # TODO cache?
         instance_eval(&value_block)
       end
@@ -334,7 +334,7 @@ module Authorization
       [user, roles, privileges]
     end
     
-    def flatten_roles (roles, flattened_roles = Set.new)
+    def flatten_roles(roles, flattened_roles = Set.new)
       # TODO caching?
       roles.reject {|role| flattened_roles.include?(role)}.each do |role|
         flattened_roles << role
@@ -344,7 +344,7 @@ module Authorization
     end
     
     # Returns the privilege hierarchy flattened for given privileges in context.
-    def flatten_privileges (privileges, context = nil, flattened_privileges = Set.new)
+    def flatten_privileges(privileges, context = nil, flattened_privileges = Set.new)
       # TODO caching?
       raise AuthorizationUsageError, "No context given or inferable from object" unless context
       privileges.reject {|priv| flattened_privileges.include?(priv)}.each do |priv|
@@ -355,7 +355,7 @@ module Authorization
       flattened_privileges.to_a
     end
     
-    def matching_auth_rules (roles, privileges, context)
+    def matching_auth_rules(roles, privileges, context)
       auth_rules.matching(roles, privileges, context)
     end
   end
@@ -366,12 +366,12 @@ module Authorization
     extend Forwardable
     def_delegators :@rules, :each, :length, :[]
 
-    def initialize (rules = [])
+    def initialize(rules = [])
       @rules = rules.clone
       reset!
     end
 
-    def initialize_copy (source)
+    def initialize_copy(source)
       @rules = @rules.collect {|rule| rule.clone}
       reset!
     end
@@ -383,15 +383,18 @@ module Authorization
         rule.matches? roles, privileges, context
       end
     end
-    def delete rule
+
+    def delete(rule)
       @rules.delete rule
       reset!
     end
-    def << rule
+
+    def <<(rule)
       @rules << rule
       reset!
     end
-    def each &block
+
+    def each(&block)
       @rules.each &block
     end
 
@@ -399,6 +402,7 @@ module Authorization
     def reset!
       @cached_auth_rules =nil
     end
+
     def cached_auth_rules
       return @cached_auth_rules if @cached_auth_rules
       @cached_auth_rules = {}
@@ -411,11 +415,12 @@ module Authorization
       @cached_auth_rules
     end
   end
+
   class AuthorizationRule
     attr_reader :attributes, :contexts, :role, :privileges, :join_operator,
         :source_file, :source_line
     
-    def initialize (role, privileges = [], contexts = nil, join_operator = :or,
+    def initialize(role, privileges = [], contexts = nil, join_operator = :or,
           options = {})
       @role = role
       @privileges = Set.new(privileges)
@@ -426,27 +431,27 @@ module Authorization
       @source_line = options[:source_line]
     end
 
-    def initialize_copy (from)
+    def initialize_copy(from)
       @privileges = @privileges.clone
       @contexts = @contexts.clone
       @attributes = @attributes.collect {|attribute| attribute.clone }
     end
     
-    def append_privileges (privs)
+    def append_privileges(privs)
       @privileges.merge(privs)
     end
     
-    def append_attribute (attribute)
+    def append_attribute(attribute)
       @attributes << attribute
     end
     
-    def matches? (roles, privs, context = nil)
+    def matches?(roles, privs, context = nil)
       roles = [roles] unless roles.is_a?(Array)
       @contexts.include?(context) and roles.include?(@role) and 
         not (@privileges & privs).empty?
     end
 
-    def validate? (attr_validator, skip_attribute = false)
+    def validate?(attr_validator, skip_attribute = false)
       skip_attribute or @attributes.empty? or
         @attributes.send(@join_operator == :and ? :all? : :any?) do |attr|
           begin
@@ -457,7 +462,7 @@ module Authorization
         end
     end
 
-    def obligations (attr_validator)
+    def obligations(attr_validator)
       exceptions = []
       obligations = @attributes.collect do |attr|
         begin
@@ -500,15 +505,15 @@ module Authorization
     # attr_conditions_hash of form
     # { :object_attribute => [operator, value_block], ... }
     # { :object_attribute => { :attr => ... } }
-    def initialize (conditions_hash)
+    def initialize(conditions_hash)
       @conditions_hash = conditions_hash
     end
 
-    def initialize_copy (from)
+    def initialize_copy(from)
       @conditions_hash = deep_hash_clone(@conditions_hash)
     end
     
-    def validate? (attr_validator, object = nil, hash = nil)
+    def validate?(attr_validator, object = nil, hash = nil)
       object ||= attr_validator.object
       return false unless object
       
@@ -602,7 +607,7 @@ module Authorization
     end
     
     # resolves all the values in condition_hash
-    def obligation (attr_validator, hash = nil)
+    def obligation(attr_validator, hash = nil)
       hash = (hash || @conditions_hash).clone
       hash.each do |attr, value|
         if value.is_a?(Hash)
@@ -616,7 +621,7 @@ module Authorization
       hash
     end
 
-    def to_long_s (hash = nil)
+    def to_long_s(hash = nil)
       if hash
         hash.inject({}) do |memo, key_val|
           key, val = key_val
@@ -632,7 +637,7 @@ module Authorization
     end
 
     protected
-    def object_attribute_value (object, attr)
+    def object_attribute_value(object, attr)
       begin
         object.send(attr)
       rescue ArgumentError, NoMethodError => e
@@ -642,7 +647,7 @@ module Authorization
       end
     end
 
-    def deep_hash_clone (hash)
+    def deep_hash_clone(hash)
       hash.inject({}) do |memo, (key, val)|
         memo[key] = case val
                     when Hash
@@ -662,17 +667,17 @@ module Authorization
   class AttributeWithPermission < Attribute
     # E.g. privilege :read, attr_or_hash either :attribute or
     # { :attribute => :deeper_attribute }
-    def initialize (privilege, attr_or_hash, context = nil)
+    def initialize(privilege, attr_or_hash, context = nil)
       @privilege = privilege
       @context = context
       @attr_hash = attr_or_hash
     end
 
-    def initialize_copy (from)
+    def initialize_copy(from)
       @attr_hash = deep_hash_clone(@attr_hash) if @attr_hash.is_a?(Hash)
     end
 
-    def validate? (attr_validator, object = nil, hash_or_attr = nil)
+    def validate?(attr_validator, object = nil, hash_or_attr = nil)
       object ||= attr_validator.object
       hash_or_attr ||= @attr_hash
       return false unless object
@@ -711,7 +716,7 @@ module Authorization
     end
 
     # may return an array of obligations to be OR'ed
-    def obligation (attr_validator, hash_or_attr = nil, path = [])
+    def obligation(attr_validator, hash_or_attr = nil, path = [])
       hash_or_attr ||= @attr_hash
       case hash_or_attr
       when Symbol
@@ -771,7 +776,7 @@ module Authorization
     end
 
     private
-    def self.reflection_for_path (parent_model, path)
+    def self.reflection_for_path(parent_model, path)
       reflection = path.empty? ? parent_model : begin
         parent = reflection_for_path(parent_model, path[0..-2])
         if !parent.respond_to?(:proxy_reflection) and parent.respond_to?(:klass)
@@ -790,7 +795,7 @@ module Authorization
   # Represents a pseudo-user to facilitate anonymous users in applications
   class AnonymousUser
     attr_reader :role_symbols
-    def initialize (roles = [Authorization.default_role])
+    def initialize(roles = [Authorization.default_role])
       @role_symbols = roles
     end
   end

--- a/lib/declarative_authorization/development_support/analyzer.rb
+++ b/lib/declarative_authorization/development_support/analyzer.rb
@@ -21,7 +21,7 @@ module Authorization
     # Merge-able Rules:  respect if_permitted_to hash
     #
     class Analyzer < AbstractAnalyzer
-      def analyze (rules)
+      def analyze(rules)
         sexp_array = RubyParser.new.parse(rules)
         #sexp_array = ParseTree.translate(rules)
         @reports = []
@@ -48,11 +48,11 @@ module Authorization
         def analyze
           mark(:policy, nil) if analyze_policy
           roles.select {|role| analyze_role(role) }.
-              each { |role| mark(:role, role) }
+            each { |role| mark(:role, role) }
           rules.select {|rule| analyze_rule(rule) }.
-              each { |rule| mark(:rule, rule) }
+            each { |rule| mark(:rule, rule) }
           privileges.select {|privilege| !!analyze_privilege(privilege) }.
-              each { |privilege| mark(:privilege, privilege) }
+            each { |privilege| mark(:privilege, privilege) }
         end
 
         protected
@@ -70,21 +70,21 @@ module Authorization
 
         # to be implemented by specific processor
         def analyze_policy; end
-        def analyze_role (a_role); end
-        def analyze_rule (a_rule); end
-        def analyze_privilege (a_privilege); end
-        def message (object); end
+        def analyze_role(a_role); end
+        def analyze_rule(a_rule); end
+        def analyze_privilege(a_privilege); end
+        def message(object); end
 
         private
-        def source_line (object)
+        def source_line(object)
           object.source_line if object.respond_to?(:source_line)
         end
 
-        def source_file (object)
+        def source_file(object)
           object.source_file if object.respond_to?(:source_file)
         end
 
-        def mark (type, object)
+        def mark(type, object)
           @analyzer.reports << Report.new(report_type,
               source_file(object), source_line(object), message(object))
         end
@@ -103,7 +103,7 @@ module Authorization
           small_roles.length > 1 and small_roles.length.to_f / roles.length.to_f > SMALL_ROLES_RATIO
         end
 
-        def message (object)
+        def message(object)
           "The ratio of small roles is quite high (> %.0f%%).  Consider refactoring." % (SMALL_ROLES_RATIO * 100)
         end
 
@@ -114,25 +114,25 @@ module Authorization
       end
 
       class InheritingPrivilegesAnalyzer < GeneralRulesAnalyzer
-        def analyze_rule (rule)
+        def analyze_rule(rule)
           rule.privileges.any? {|privilege| rule.privileges.intersects?(privilege.ancestors) }
         end
 
-        def message (object)
+        def message(object)
           "At least one privilege inherits from another in this rule."
         end
       end
 
       class ProposedPrivilegeHierarchyAnalyzer < GeneralRulesAnalyzer
         # TODO respect, consider contexts
-        def analyze_privilege (privilege)
+        def analyze_privilege(privilege)
           privileges.find do |other_privilege|
             other_privilege != privilege and
                 other_privilege.rules.all? {|rule| rule.privileges.include?(privilege)}
           end
         end
 
-        def message (privilege)
+        def message(privilege)
           other_privilege = analyze_privilege(privilege)
           "Privilege #{other_privilege.to_sym} is always used together with #{privilege.to_sym}. " +
               "Consider to include #{other_privilege.to_sym} in #{privilege.to_sym}."
@@ -148,7 +148,7 @@ module Authorization
           @analyzer = analyzer
         end
 
-        def analyze (sexp_array)
+        def analyze(sexp_array)
           process(sexp_array)
           analyze_rules
         end
@@ -157,19 +157,19 @@ module Authorization
           # to be implemented by specific processor
         end
 
-        def process_iter (exp)
+        def process_iter(exp)
           s(:iter, process(exp.shift), process(exp.shift), process(exp.shift))
         end
 
-        def process_arglist (exp)
+        def process_arglist(exp)
           s(exp.collect {|inner_exp| process(inner_exp).shift})
         end
 
-        def process_hash (exp)
+        def process_hash(exp)
           s(Hash[*exp.collect {|inner_exp| process(inner_exp).shift}])
         end
 
-        def process_lit (exp)
+        def process_lit(exp)
           s(exp.shift)
         end
       end
@@ -198,7 +198,7 @@ module Authorization
           end
         end
 
-        def process_call (exp)
+        def process_call(exp)
           klass = exp.shift
           name = exp.shift
           case name
@@ -249,7 +249,7 @@ module Authorization
 
       class Report
         attr_reader :type, :filename, :line, :message
-        def initialize (type, filename, line, msg)
+        def initialize(type, filename, line, msg)
           @type = type
           @filename = filename
           @line = line

--- a/lib/declarative_authorization/development_support/change_analyzer.rb
+++ b/lib/declarative_authorization/development_support/change_analyzer.rb
@@ -27,7 +27,7 @@ module Authorization
     #
     class ChangeAnalyzer < AbstractAnalyzer
 
-      def find_approaches_for (change_action, type, options, &tests)
+      def find_approaches_for(change_action, type, options, &tests)
         raise ArgumentError, "Missing options" if !options[:on] or !options[:to]
 
         # * strategy for removing: [remove privilege, add privilege to different role]
@@ -69,11 +69,11 @@ module Authorization
       class ApproachChecker
         attr_reader :failed_test_count, :users
 
-        def initialize (analyzer, tests)
+        def initialize(analyzer, tests)
           @analyzer, @tests = analyzer, tests
         end
 
-        def check (engine, users)
+        def check(engine, users)
           @current_engine = engine
           @failed_test_count = 0
           @users = users
@@ -82,30 +82,30 @@ module Authorization
           @ok
         end
 
-        def assert (ok)
+        def assert(ok)
           @failed_test_count += 1 unless ok
           @ok &&= ok
         end
 
-        def permit? (*args)
+        def permit?(*args)
           @current_engine.permit?(*args)
         end
       end
 
       class Approach
         attr_reader :steps, :engine, :users
-        def initialize (engine, users, steps)
+        def initialize(engine, users, steps)
           @engine, @users, @steps = engine, users, steps
         end
 
-        def check (approach_checker)
+        def check(approach_checker)
           res = approach_checker.check(@engine, @users)
           @failed_test_count = approach_checker.failed_test_count
           #puts "CHECKING #{inspect} (#{res}, #{sort_value})"
           res
         end
 
-        def clone_for_step (*step_params)
+        def clone_for_step(*step_params)
           self.class.new(@engine.clone, @users.clone, @steps + [Step.new(step_params)])
         end
 
@@ -113,7 +113,7 @@ module Authorization
           @steps.select {|step| step.length > 1}
         end
 
-        def subset? (other_approach)
+        def subset?(other_approach)
           other_approach.changes.length >= changes.length &&
               changes.all? {|step| other_approach.changes.any? {|step_2| step_2.eql?(step)} }
         end
@@ -138,13 +138,13 @@ module Authorization
              # "\n  Users: #{@users.map(&:role_symbols).inspect}"
         end
 
-        def <=> (other)
+        def <=>(other)
           sort_value <=> other.sort_value
         end
       end
 
       class Step < Array
-        def eql? (other)
+        def eql?(other)
           # TODO use approach.users.index(self[idx]) ==
           #    other.approach.users.index(other[idx])
           # instead of user.login
@@ -161,7 +161,7 @@ module Authorization
       end
 
       protected
-      def next_step (viable_approaches, candidates, approach_checker,
+      def next_step(viable_approaches, candidates, approach_checker,
             privilege, context, strategy)
         candidate = candidates.shift
         next_in_strategy = strategy[candidate.steps.length % strategy.length]
@@ -242,7 +242,7 @@ module Authorization
         candidates.sort!
       end
 
-      def relevant_roles (approach)
+      def relevant_roles(approach)
         #return AnalyzerEngine.roles(approach.engine)
         (AnalyzerEngine.relevant_roles(approach.engine, approach.users) +
             (approach.engine.roles.include?(:new_role_for_change_analyzer) ?

--- a/lib/declarative_authorization/development_support/change_supporter.rb
+++ b/lib/declarative_authorization/development_support/change_supporter.rb
@@ -45,7 +45,7 @@ module Authorization
       # permission tests in the block.  The instance method +users+ is available
       # when the block is executed to refer to the then-current users, whose
       # roles might have changed as one suggestion.
-      def find_approaches_for (options, &tests)
+      def find_approaches_for(options, &tests)
         @prohibited_actions = (options[:prohibited_actions] || []).to_set
 
         @approaches_by_actions = {}
@@ -72,7 +72,7 @@ module Authorization
 
       # Returns an array of GroupedApproaches for the given array of approaches.
       # Only groups directly adjacent approaches
-      def group_approaches (approaches)
+      def group_approaches(approaches)
         approaches.each_with_object([]) do |approach, grouped|
           if grouped.last and grouped.last.approach.similar_to(approach)
             grouped.last.similar_approaches << approach
@@ -84,7 +84,7 @@ module Authorization
 
       class GroupedApproach
         attr_accessor :approach, :similar_approaches
-        def initialize (approach)
+        def initialize(approach)
           @approach = approach
           @similar_approaches = []
         end
@@ -93,11 +93,11 @@ module Authorization
       class ApproachChecker
         attr_reader :users, :failed_tests
 
-        def initialize (analyzer, tests)
+        def initialize(analyzer, tests)
           @analyzer, @tests = analyzer, tests
         end
 
-        def check (engine, users)
+        def check(engine, users)
           @current_engine = engine
           @failed_tests = []
           @current_test_args = nil
@@ -108,12 +108,12 @@ module Authorization
           @ok
         end
 
-        def assert (ok)
+        def assert(ok)
           @failed_tests << Test.new(*([!@current_permit_result] + @current_test_args)) unless ok
           @ok &&= ok
         end
 
-        def permit? (*args)
+        def permit?(*args)
           @current_test_args = args
           @current_permit_result = @current_engine.permit?(
               *(args[0...-1] + [args.last.merge(:skip_attribute_test => true)]))
@@ -122,7 +122,7 @@ module Authorization
 
       class Test
         attr_reader :positive, :privilege, :context, :user
-        def initialize (positive, privilege, options = {})
+        def initialize(positive, privilege, options = {})
           @positive, @privilege = positive, privilege
           @context = options[:context]
           @user = options[:user]
@@ -131,18 +131,18 @@ module Authorization
 
       class Approach
         attr_reader :steps, :engine, :users, :failed_tests
-        def initialize (engine, users, steps)
+        def initialize(engine, users, steps)
           @engine, @users, @steps = engine, users, steps
         end
 
-        def check (approach_checker)
+        def check(approach_checker)
           res = approach_checker.check(@engine, @users)
           @failed_tests = approach_checker.failed_tests
           #puts "CHECKING #{inspect} (#{res}, #{sort_value})"
           res
         end
 
-        def affected_users (original_engine, original_users, privilege, context)
+        def affected_users(original_engine, original_users, privilege, context)
           (0...@users.length).select do |i|
             original_engine.permit?(privilege, :context => context,
               :skip_attribute_test => true, :user => original_users[i]) !=
@@ -151,7 +151,7 @@ module Authorization
           end.collect {|i| original_users[i]}
         end
 
-        def initialize_copy (other)
+        def initialize_copy(other)
           @engine = @engine.clone
           @users = @users.clone
           @steps = @steps.clone
@@ -177,17 +177,17 @@ module Authorization
           end
         end
 
-        def reverse_of_previous? (specific_action)
+        def reverse_of_previous?(specific_action)
           changes.any? {|step| step.reverse?(specific_action)}
         end
 
-        def apply (action)
+        def apply(action)
           ok = action.apply(self)
           @steps << action if ok
           ok
         end
 
-        def subset? (other_approach)
+        def subset?(other_approach)
           other_approach.changes.length >= changes.length &&
               changes.all? {|step| other_approach.changes.any? {|step_2| step_2.eql?(step)} }
         end
@@ -210,7 +210,7 @@ module Authorization
           changes.sum(&:weight)
         end
 
-        def similar_to (other)
+        def similar_to(other)
           other.weight == weight and
               other.changes.map {|change| change.class.name}.sort ==
                 changes.map {|change| change.class.name}.sort
@@ -222,7 +222,7 @@ module Authorization
              # "\n  Users: #{@users.map(&:role_symbols).inspect}"
         end
 
-        def <=> (other)
+        def <=>(other)
           sort_value <=> other.sort_value
         end
       end
@@ -233,16 +233,16 @@ module Authorization
         end
 
         # returns a list of instances of the action that may be applied
-        def self.specific_actions (candidate)
+        def self.specific_actions(candidate)
           raise NotImplementedError, "Not yet?"
         end
 
         # applies the specific action on the given candidate
-        def apply (candidate)
+        def apply(candidate)
           raise NotImplementedError, "Not yet?"
         end
 
-        def eql? (other)
+        def eql?(other)
           other.class == self.class and hash == other.hash
         end
 
@@ -250,7 +250,7 @@ module Authorization
           @hash ||= to_a.hash
         end
 
-        def reverse? (other)
+        def reverse?(other)
           false
         end
 
@@ -262,16 +262,16 @@ module Authorization
           [:abstract]
         end
 
-        def resembles? (spec)
+        def resembles?(spec)
           min_length = [spec.length, to_a.length].min
           to_a[0,min_length] == spec[0,min_length]
         end
 
-        def resembles_any? (specs)
+        def resembles_any?(specs)
           specs.any? {|spec| resembles?(spec) }
         end
 
-        def self.readable_info (info)
+        def self.readable_info(info)
           if info.respond_to?(:to_sym)
             info.to_sym.inspect
           else
@@ -285,11 +285,11 @@ module Authorization
           @actions.sum(&:weight) + 1
         end
 
-        def apply (candidate)
+        def apply(candidate)
           @actions.all? {|action| action.apply(candidate)}
         end
 
-        def reverse? (other)
+        def reverse?(other)
           @actions.any? {|action| action.reverse?(other)}
         end
 
@@ -301,7 +301,7 @@ module Authorization
           @hash ||= @actions.inject(0) {|memo, action| memo += action.hash }
         end
 
-        def resembles? (spec)
+        def resembles?(spec)
           @actions.any? {|action| action.resembles?(spec) } or
             to_a.any? do |array|
               min_length = [spec.length, array.length].min
@@ -311,7 +311,7 @@ module Authorization
       end
 
       class AssignPrivilegeToRoleAction < AbstractAction
-        def self.specific_actions (candidate)
+        def self.specific_actions(candidate)
           privilege = AnalyzerEngine::Privilege.for_sym(
               candidate.failed_tests.first.privilege, candidate.engine)
           context = candidate.failed_tests.first.context
@@ -326,15 +326,15 @@ module Authorization
         end
 
         attr_reader :privilege, :context, :role
-        def initialize (privilege_sym, context, role_sym)
+        def initialize(privilege_sym, context, role_sym)
           @privilege, @context, @role = privilege_sym, context, role_sym
         end
 
-        def apply (candidate)
+        def apply(candidate)
           AnalyzerEngine.apply_change(candidate.engine, to_a)
         end
 
-        def reverse? (other)
+        def reverse?(other)
           other.is_a?(RemovePrivilegeFromRoleAction) and
               other.privilege == @privilege and
               other.context == @context and
@@ -347,7 +347,7 @@ module Authorization
       end
 
       class AssignRoleToUserAction < AbstractAction
-        def self.specific_actions (candidate)
+        def self.specific_actions(candidate)
           privilege = candidate.failed_tests.first.privilege
           context = candidate.failed_tests.first.context
           user = candidate.failed_tests.first.user
@@ -357,11 +357,11 @@ module Authorization
         end
 
         attr_reader :user, :role
-        def initialize (user, role_sym)
+        def initialize(user, role_sym)
           @user, @role = user, role_sym
         end
 
-        def apply (candidate)
+        def apply(candidate)
           if candidate.engine.roles_with_hierarchy_for(@user).include?(@role)
             false
           else
@@ -381,13 +381,13 @@ module Authorization
           to_a[0,2].hash + @user.login.hash
         end
 
-        def reverse? (other)
+        def reverse?(other)
           other.is_a?(RemoveRoleFromUserAction) and
               other.user.login == @user.login and
               other.role == @role
         end
 
-        def resembles? (spec)
+        def resembles?(spec)
           super(spec[0,2]) and (spec.length == 2 or spec[2] == @user.login)
         end
 
@@ -397,7 +397,7 @@ module Authorization
       end
 
       class CreateAndAssignRoleToUserAction < AbstractCompoundAction
-        def self.specific_actions (candidate)
+        def self.specific_actions(candidate)
           privilege = AnalyzerEngine::Privilege.for_sym(
               candidate.failed_tests.first.privilege, candidate.engine)
           context = candidate.failed_tests.first.context
@@ -409,12 +409,12 @@ module Authorization
         end
 
         attr_reader :user, :privilege, :context, :role
-        def initialize (user, privilege_sym, context_sym, role_sym)
+        def initialize(user, privilege_sym, context_sym, role_sym)
           @user, @privilege, @context, @role = user, privilege_sym, context_sym, role_sym
           @actions = [AddPrivilegeAndAssignRoleToUserAction.new(@user, @privilege, @context, role_sym)]
         end
 
-        def apply (candidate)
+        def apply(candidate)
           if AnalyzerEngine.apply_change(candidate.engine, [:add_role, @role])
             super(candidate)
           else
@@ -432,7 +432,7 @@ module Authorization
       end
 
       class AddPrivilegeAndAssignRoleToUserAction < AbstractCompoundAction
-        def self.specific_actions (candidate)
+        def self.specific_actions(candidate)
           privilege = AnalyzerEngine::Privilege.for_sym(
               candidate.failed_tests.first.privilege, candidate.engine)
           context = candidate.failed_tests.first.context
@@ -445,7 +445,7 @@ module Authorization
         end
 
         attr_reader :user, :privilege, :context, :role
-        def initialize (user, privilege_sym, context, role_sym)
+        def initialize(user, privilege_sym, context, role_sym)
           @user, @privilege, @context, @role = user, privilege_sym, context, role_sym
           @actions = [
             AssignRoleToUserAction.new(@user, @role),
@@ -455,7 +455,7 @@ module Authorization
       end
 
       class RemovePrivilegeFromRoleAction < AbstractAction
-        def self.specific_actions (candidate)
+        def self.specific_actions(candidate)
           privilege = AnalyzerEngine::Privilege.for_sym(
               candidate.failed_tests.first.privilege, candidate.engine)
           context = candidate.failed_tests.first.context
@@ -469,15 +469,15 @@ module Authorization
         end
 
         attr_reader :privilege, :context, :role
-        def initialize (privilege_sym, context, role_sym)
+        def initialize(privilege_sym, context, role_sym)
           @privilege, @context, @role = privilege_sym, context, role_sym
         end
 
-        def apply (candidate)
+        def apply(candidate)
           AnalyzerEngine.apply_change(candidate.engine, to_a)
         end
         
-        def reverse? (other)
+        def reverse?(other)
           (other.is_a?(AssignPrivilegeToRoleAction) or
               other.is_a?(AbstractCompoundAction)) and
                 other.reverse?(self)
@@ -489,7 +489,7 @@ module Authorization
       end
 
       class RemoveRoleFromUserAction < AbstractAction
-        def self.specific_actions (candidate)
+        def self.specific_actions(candidate)
           privilege = candidate.failed_tests.first.privilege
           context = candidate.failed_tests.first.context
           user = candidate.failed_tests.first.user
@@ -502,11 +502,11 @@ module Authorization
         end
 
         attr_reader :user, :role
-        def initialize (user, role_sym)
+        def initialize(user, role_sym)
           @user, @role = user, role_sym
         end
 
-        def apply (candidate)
+        def apply(candidate)
           # beware of shallow copies!
           cloned_user = @user.clone
           user_index = candidate.users.index(@user)
@@ -521,13 +521,13 @@ module Authorization
           to_a[0,2].hash + @user.login.hash
         end
 
-        def reverse? (other)
+        def reverse?(other)
           (other.is_a?(AssignRoleToUserAction) or
               other.is_a?(AbstractCompoundAction)) and
                 other.reverse?(self)
         end
 
-        def resembles? (spec)
+        def resembles?(spec)
           super(spec[0,2]) and (spec.length == 2 or spec[2] == @user.login)
         end
 
@@ -537,7 +537,7 @@ module Authorization
       end
 
       protected
-      def next_step (viable_approaches, candidates, approach_checker)
+      def next_step(viable_approaches, candidates, approach_checker)
         candidate = candidates.shift
 
         child_candidates = generate_child_candidates(candidate)
@@ -547,7 +547,7 @@ module Authorization
         child_candidates.length
       end
 
-      def generate_child_candidates (candidate)
+      def generate_child_candidates(candidate)
         child_candidates = []
         abstract_actions = candidate.abstract_actions
         abstract_actions.each do |abstract_action|
@@ -563,7 +563,7 @@ module Authorization
         child_candidates
       end
 
-      def check_child_candidates! (approach_checker, viable_approaches, candidates, child_candidates)
+      def check_child_candidates!(approach_checker, viable_approaches, candidates, child_candidates)
         child_candidates.each do |child_candidate|
           if child_candidate.check(approach_checker)
             unless superset_of_existing?(child_candidate)
@@ -578,13 +578,13 @@ module Authorization
         end
       end
 
-      def superset_of_existing? (candidate)
+      def superset_of_existing?(candidate)
         candidate.changes.any? do |action|
           (@approaches_by_actions[action] ||= []).any? {|approach| approach.subset?(candidate)}
         end
       end
 
-      def remove_supersets! (existing, candidate)
+      def remove_supersets!(existing, candidate)
         candidate.changes.inject([]) do |memo, action|
           memo += (@approaches_by_actions[action] ||= []).select do |approach|
             candidate.subset?(approach)
@@ -595,22 +595,22 @@ module Authorization
         end
       end
 
-      def add_to_approaches_by_action! (candidate)
+      def add_to_approaches_by_action!(candidate)
         candidate.changes.each do |action|
           (@approaches_by_actions[action] ||= []) << candidate
         end
       end
 
-      def remove_from_approaches_by_action! (candidate)
+      def remove_from_approaches_by_action!(candidate)
         candidate.changes.each do |action|
           (@approaches_by_actions[action] ||= []).delete(candidate)
         end
       end
 
-      def relevant_roles (approach)
+      def relevant_roles(approach)
         self.class.relevant_roles(approach)
       end
-      def self.relevant_roles (approach)
+      def self.relevant_roles(approach)
         (AnalyzerEngine.relevant_roles(approach.engine, approach.users) +
             (approach.engine.roles.include?(:new_role_for_change_analyzer) ?
                [AnalyzerEngine::Role.for_sym(:new_role_for_change_analyzer, approach.engine)] : [])).uniq

--- a/lib/declarative_authorization/helper.rb
+++ b/lib/declarative_authorization/helper.rb
@@ -28,7 +28,7 @@ module Authorization
     # options:
     #     permitted_to? :update, user, :context => :account
     # 
-    def permitted_to? (privilege, object_or_sym = nil, options = {}, &block)
+    def permitted_to?(privilege, object_or_sym = nil, options = {}, &block)
       controller.permitted_to?(privilege, object_or_sym, options, &block)
     end
   
@@ -48,7 +48,7 @@ module Authorization
     #     ...
     #     <% end %>
     # 
-    def has_role? (*roles, &block)
+    def has_role?(*roles, &block)
       controller.has_role?(*roles, &block)
     end
     

--- a/lib/declarative_authorization/in_controller.rb
+++ b/lib/declarative_authorization/in_controller.rb
@@ -23,7 +23,7 @@ module Authorization
     def self.failed_auto_loading_is_not_found?
       @@failed_auto_loading_is_not_found
     end
-    def self.failed_auto_loading_is_not_found= (new_value)
+    def self.failed_auto_loading_is_not_found=(new_value)
       @@failed_auto_loading_is_not_found = new_value
     end
 
@@ -42,7 +42,7 @@ module Authorization
     # If no object or context is specified, the controller_name is used as
     # context.
     #
-    def permitted_to? (privilege, object_or_sym = nil, options = {})
+    def permitted_to?(privilege, object_or_sym = nil, options = {})
       if authorization_engine.permit!(privilege, options_for_permit(object_or_sym, options, false))
         yield if block_given?
         true
@@ -53,7 +53,7 @@ module Authorization
     
     # Works similar to the permitted_to? method, but
     # throws the authorization exceptions, just like Engine#permit!
-    def permitted_to! (privilege, object_or_sym = nil, options = {})
+    def permitted_to!(privilege, object_or_sym = nil, options = {})
       authorization_engine.permit!(privilege, options_for_permit(object_or_sym, options, true))
     end
 
@@ -61,7 +61,7 @@ module Authorization
     # content should only be shown to some users without being concerned
     # with authorization.  E.g. to only show the most relevant menu options 
     # to a certain group of users.  That is what has_role? should be used for.
-    def has_role? (*roles, &block)
+    def has_role?(*roles, &block)
       user_roles = authorization_engine.roles_for(current_user)
       result = roles.all? do |role|
         user_roles.include?(role)
@@ -137,19 +137,19 @@ module Authorization
       end
     end
 
-    def load_controller_object (context_without_namespace = nil, model = nil) # :nodoc:
+    def load_controller_object(context_without_namespace = nil, model = nil) # :nodoc:
       instance_var = :"@#{context_without_namespace.to_s.singularize}"
       model = model ? model.classify.constantize : context_without_namespace.to_s.classify.constantize
       instance_variable_set(instance_var, model.find(params[:id]))
     end
 
-    def load_parent_controller_object (parent_context_without_namespace) # :nodoc:
+    def load_parent_controller_object(parent_context_without_namespace) # :nodoc:
       instance_var = :"@#{parent_context_without_namespace.to_s.singularize}"
       model = parent_context_without_namespace.to_s.classify.constantize
       instance_variable_set(instance_var, model.find(params[:"#{parent_context_without_namespace.to_s.singularize}_id"]))
     end
 
-    def new_controller_object_from_params (context_without_namespace, parent_context_without_namespace, strong_params) # :nodoc:
+    def new_controller_object_from_params(context_without_namespace, parent_context_without_namespace, strong_params) # :nodoc:
       model_or_proxy = parent_context_without_namespace ?
            instance_variable_get(:"@#{parent_context_without_namespace.to_s.singularize}").send(context_without_namespace.to_sym) :
            context_without_namespace.to_s.classify.constantize
@@ -158,7 +158,7 @@ module Authorization
         model_or_proxy.new(params[context_without_namespace.to_s.singularize]))
     end
 
-    def new_blank_controller_object (context_without_namespace, parent_context_without_namespace, strong_params, model) # :nodoc:
+    def new_blank_controller_object(context_without_namespace, parent_context_without_namespace, strong_params, model) # :nodoc:
       if model
         model_or_proxy = model.to_s.classify.constantize
       else
@@ -171,7 +171,7 @@ module Authorization
         model_or_proxy.new())
     end
 
-    def new_controller_object_for_collection (context_without_namespace, parent_context_without_namespace, strong_params) # :nodoc:
+    def new_controller_object_for_collection(context_without_namespace, parent_context_without_namespace, strong_params) # :nodoc:
       model_or_proxy = parent_context_without_namespace ?
            instance_variable_get(:"@#{parent_context_without_namespace.to_s.singularize}").send(context_without_namespace.to_sym) :
            context_without_namespace.to_s.classify.constantize
@@ -179,7 +179,7 @@ module Authorization
       instance_variable_set(instance_var, model_or_proxy.new)
     end
 
-    def options_for_permit (object_or_sym = nil, options = {}, bang = true)
+    def options_for_permit(object_or_sym = nil, options = {}, bang = true)
       context = object = nil
       if object_or_sym.nil?
         context = self.class.decl_auth_context
@@ -296,7 +296,7 @@ module Authorization
       #                      :load_method => lambda { User.find(params[:id]) }
       # 
       
-      def filter_access_to (*args, &filter_block)
+      def filter_access_to(*args, &filter_block)
         options = args.last.is_a?(Hash) ? args.pop : {}
         options = {
           :require => nil,
@@ -611,7 +611,7 @@ module Authorization
         class_variable_defined?(:@@declarative_authorization_permissions)
       end
 
-      def actions_from_option (option) # :nodoc:
+      def actions_from_option(option) # :nodoc:
         case option
         when nil
           {}
@@ -635,7 +635,7 @@ module Authorization
   
   class ControllerPermission # :nodoc:
     attr_reader :actions, :privilege, :context, :attribute_check, :strong_params
-    def initialize (actions, privilege, context, strong_params, attribute_check = false,
+    def initialize(actions, privilege, context, strong_params, attribute_check = false,
                     load_object_model = nil, load_object_method = nil,
                     filter_block = nil)
       @actions = actions.to_set
@@ -648,11 +648,11 @@ module Authorization
       @strong_params = strong_params
     end
     
-    def matches? (action_name)
+    def matches?(action_name)
       @actions.include?(action_name.to_sym)
     end
     
-    def permit! (contr)
+    def permit!(contr)
       if @filter_block
         return contr.instance_eval(&@filter_block)
       end
@@ -666,7 +666,7 @@ module Authorization
                                          :context => @context || contr.class.decl_auth_context)
     end
     
-    def remove_actions (actions)
+    def remove_actions(actions)
       @actions -= actions
       self
     end

--- a/lib/declarative_authorization/in_model.rb
+++ b/lib/declarative_authorization/in_model.rb
@@ -8,7 +8,7 @@ module Authorization
 
     # If the user meets the given privilege, permitted_to? returns true
     # and yields to the optional block.
-    def permitted_to? (privilege, options = {}, &block)
+    def permitted_to?(privilege, options = {}, &block)
       options = {
         :user =>  Authorization.current_user,
         :object => self
@@ -21,7 +21,7 @@ module Authorization
 
     # Works similar to the permitted_to? method, but doesn't accept a block
     # and throws the authorization exceptions, just like Engine#permit!
-    def permitted_to! (privilege, options = {} )
+    def permitted_to!(privilege, options = {} )
       options = {
         :user =>  Authorization.current_user,
         :object => self
@@ -97,7 +97,7 @@ module Authorization
         #   User to be used for gathering obligations; defaults to the
         #   current user.
         #
-        def self.with_permissions_to (*args)
+        def self.with_permissions_to(*args)
           if Rails.version < "3.1"
             scopes[:with_permissions_to].call(self, *args)
           else
@@ -146,7 +146,7 @@ module Authorization
         # [:+context+] Specify context different from the models table name.
         # [:+include_read+] Also check for :+read+ privilege after find.
         #
-        def self.using_access_control (options = {})
+        def self.using_access_control(options = {})
           options = {
             :context => nil,
             :include_read => false

--- a/lib/declarative_authorization/maintenance.rb
+++ b/lib/declarative_authorization/maintenance.rb
@@ -15,7 +15,7 @@ module Authorization
     #  without_access_control do
     #    SomeModel.find(:first).save
     #  end
-    def without_access_control (&block)
+    def without_access_control(&block)
       Authorization::Maintenance.without_access_control(&block)
     end
 
@@ -36,11 +36,11 @@ module Authorization
     # Sets the current user for the declarative authorization plugin to the
     # given one for the execution of the supplied block.  Suitable for tests
     # on certain users.
-    def with_user (user, &block)
+    def with_user(user, &block)
       Authorization::Maintenance.with_user(user, &block)
     end
 
-    def self.with_user (user)
+    def self.with_user(user)
       prev_user = Authorization.current_user
       Authorization.current_user = user
       yield
@@ -140,7 +140,7 @@ module Authorization
     
     # Analogue to the Ruby's assert_raise method, only executing the block
     # in the context of the given user.
-    def assert_raise_with_user (user, *args, &block)
+    def assert_raise_with_user(user, *args, &block)
       assert_raise(*args) do
         with_user(user, &block)
       end
@@ -158,7 +158,7 @@ module Authorization
     #
     # If you use specify the object and context manually, you can also specify the user manually, skipping the with_user block:
     #   should_be_allowed_to :create, :object => car, :context => :vehicles, :user => a_normal_user
-    def should_be_allowed_to (privilege, *args)
+    def should_be_allowed_to(privilege, *args)
       options = {}
       if(args.first.class == Hash)
         options = args.extract_options!
@@ -171,7 +171,7 @@ module Authorization
     end
 
     # See should_be_allowed_to
-    def should_not_be_allowed_to (privilege, *args)
+    def should_not_be_allowed_to(privilege, *args)
       options = {}
       if(args.first.class == Hash)
         options = args.extract_options!
@@ -181,7 +181,7 @@ module Authorization
       assert !Authorization::Engine.instance.permit?(privilege, options)
     end
     
-    def request_with (user, method, xhr, action, params = {}, 
+    def request_with(user, method, xhr, action, params = {}, 
         session = {}, flash = {})
       session = session.merge({:user => user, :user_id => user && user.id})
       with_user(user) do
@@ -193,14 +193,14 @@ module Authorization
       end
     end
   
-    def self.included (base)
+    def self.included(base)
       [:get, :post, :put, :delete].each do |method|
         base.class_eval <<-EOV, __FILE__, __LINE__
-          def #{method}_with (user, *args)
+          def #{method}_with(user, *args)
             request_with(user, #{method.inspect}, false, *args)
           end
 
-          def #{method}_by_xhr_with (user, *args)
+          def #{method}_by_xhr_with(user, *args)
             request_with(user, #{method.inspect}, true, *args)
           end
         EOV

--- a/lib/declarative_authorization/obligation_scope.rb
+++ b/lib/declarative_authorization/obligation_scope.rb
@@ -43,7 +43,7 @@ module Authorization
   # @proxy_options[:conditions] = [ 'foos_bazzes.attr = :foos_bazzes__id_0', { :foos_bazzes__id_0 => 1 } ]+
   #
   class ObligationScope < (Rails.version < "3" ? ActiveRecord::NamedScope::Scope : ActiveRecord::Relation)
-    def initialize (model, options)
+    def initialize(model, options)
       @finder_options = {}
       if Rails.version < "3"
         super(model, options)
@@ -141,7 +141,7 @@ module Authorization
     end
     
     # Returns the model associated with the given path.
-    def model_for (path)
+    def model_for(path)
       reflection = reflection_for(path)
 
       if Authorization.is_a_association_proxy?(reflection)
@@ -294,7 +294,7 @@ module Authorization
       finder_options[:conditions] = [ conds.join( " OR " ), binds ]
     end
 
-    def attribute_value (value)
+    def attribute_value(value)
       value.class.respond_to?(:descends_from_active_record?) && value.class.descends_from_active_record? && value.id ||
         value.is_a?(Array) && value[0].class.respond_to?(:descends_from_active_record?) && value[0].class.descends_from_active_record? && value.map( &:id ) ||
         value
@@ -335,7 +335,7 @@ module Authorization
       end
     end
 
-    def path_to_join (path)
+    def path_to_join(path)
       case path.length
       when 0 then nil
       when 1 then path[0]
@@ -348,7 +348,7 @@ module Authorization
       end
     end
 
-    def join_to_path (join)
+    def join_to_path(join)
       case join
       when Symbol
         [join]

--- a/lib/declarative_authorization/reader.rb
+++ b/lib/declarative_authorization/reader.rb
@@ -54,12 +54,12 @@ module Authorization
     class DSLReader
       attr_reader :privileges_reader, :auth_rules_reader # :nodoc:
 
-      def initialize ()
+      def initialize()
         @privileges_reader = PrivilegesReader.new
         @auth_rules_reader = AuthorizationRulesReader.new
       end
 
-      def initialize_copy (from) # :nodoc:
+      def initialize_copy(from) # :nodoc:
         @privileges_reader = from.privileges_reader.clone
         @auth_rules_reader = from.auth_rules_reader.clone
       end
@@ -79,7 +79,7 @@ module Authorization
 
       # Parses a authorization DSL specification from the string given
       # in +dsl_data+.  Raises DSLSyntaxError if errors occur on parsing.
-      def parse (dsl_data, file_name = nil)
+      def parse(dsl_data, file_name = nil)
         if file_name
           DSLMethods.new(self).instance_eval(dsl_data, file_name)
         else
@@ -90,19 +90,19 @@ module Authorization
       end
 
       # Load and parse a DSL from the given file name.
-      def load (dsl_file)
+      def load(dsl_file)
         parse(File.read(dsl_file), dsl_file) if File.exist?(dsl_file)
       end
 
       # Load and parse a DSL from the given file name. Raises Authorization::Reader::DSLFileNotFoundError
       # if the file cannot be found.
-      def load! (dsl_file)
+      def load!(dsl_file)
         raise ::Authorization::Reader::DSLFileNotFoundError, "Error reading authorization rules file with path '#{dsl_file}'!  Please ensure it exists and that it is accessible." unless File.exist?(dsl_file)
         load(dsl_file)
       end
 
       # Loads and parses DSL files and returns a new reader
-      def self.load (dsl_files)
+      def self.load(dsl_files)
         # TODO cache reader in production mode?
         reader = new
         dsl_files = [dsl_files].flatten
@@ -114,19 +114,19 @@ module Authorization
 
       # DSL methods
       class DSLMethods # :nodoc:
-        def initialize (parent)
+        def initialize(parent)
           @parent = parent
         end
 
-        def privileges (&block)
+        def privileges(&block)
           @parent.privileges_reader.instance_eval(&block)
         end
 
-        def contexts (&block)
+        def contexts(&block)
           # Not implemented
         end
 
-        def authorization (&block)
+        def authorization(&block)
           @parent.auth_rules_reader.instance_eval(&block)
         end
       end
@@ -146,12 +146,12 @@ module Authorization
         @privilege_hierarchy = {}
       end
 
-      def initialize_copy (from) # :nodoc:
+      def initialize_copy(from) # :nodoc:
         @privileges = from.privileges.clone
         @privilege_hierarchy = from.privilege_hierarchy.clone
       end
 
-      def append_privilege (priv) # :nodoc:
+      def append_privilege(priv) # :nodoc:
         @privileges << priv unless @privileges.include?(priv)
       end
 
@@ -160,7 +160,7 @@ module Authorization
       # or as option :+includes+.  If the optional context is given,
       # the privilege hierarchy is limited to that context.
       #
-      def privilege (privilege, context = nil, options = {}, &block)
+      def privilege(privilege, context = nil, options = {}, &block)
         if context.is_a?(Hash)
           options = context
           context = nil
@@ -177,7 +177,7 @@ module Authorization
 
       # Specifies +privileges+ that are to be assigned as lower ones.  Only to
       # be used inside a privilege block.
-      def includes (*privileges)
+      def includes(*privileges)
         raise DSLError, "includes only in privilege block" if @current_priv.nil?
         privileges.each do |priv|
           append_privilege priv
@@ -203,14 +203,14 @@ module Authorization
         @auth_rules = AuthorizationRuleSet.new
       end
 
-      def initialize_copy (from) # :nodoc:
+      def initialize_copy(from) # :nodoc:
         [:roles, :role_hierarchy, :auth_rules,
             :role_descriptions, :role_titles, :omnipotent_roles].each do |attribute|
           instance_variable_set(:"@#{attribute}", from.send(attribute).clone)
         end
       end
 
-      def append_role (role, options = {}) # :nodoc:
+      def append_role(role, options = {}) # :nodoc:
         @roles << role unless @roles.include? role
         @role_titles[role] = options[:title] if options[:title]
         @role_descriptions[role] = options[:description] if options[:description]
@@ -222,7 +222,7 @@ module Authorization
       #     has_permissions_on ...
       #   end
       #
-      def role (role, options = {}, &block)
+      def role(role, options = {}, &block)
         append_role role, options
         @current_role = role
         yield
@@ -240,7 +240,7 @@ module Authorization
       #     has_permission_on :employees, :to => :read
       #   end
       #
-      def includes (*roles)
+      def includes(*roles)
         raise DSLError, "includes only in role blocks" if @current_role.nil?
         @role_hierarchy[@current_role] ||= []
         @role_hierarchy[@current_role] += roles.flatten
@@ -274,7 +274,7 @@ module Authorization
       #   Join operator to logically connect the constraint statements inside
       #   of the has_permission_on block.  May be :+and+ or :+or+.  Defaults to :+or+.
       #
-      def has_permission_on (*args, &block)
+      def has_permission_on(*args, &block)
         options = args.extract_options!
         context = args.flatten
         
@@ -312,7 +312,7 @@ module Authorization
       #     description "To be assigned to administrative personnel"
       #     has_permission_on ...
       #   end
-      def description (text)
+      def description(text)
         raise DSLError, "description only allowed in role blocks" if @current_role.nil?
         role_descriptions[@current_role] = text
       end
@@ -322,7 +322,7 @@ module Authorization
       #     title "Administrator"
       #     has_permission_on ...
       #   end
-      def title (text)
+      def title(text)
         raise DSLError, "title only allowed in role blocks" if @current_role.nil?
         role_titles[@current_role] = text
       end
@@ -335,7 +335,7 @@ module Authorization
       #       to :create, :read, :update, :delete
       #     end
       #   end
-      def to (*privs)
+      def to(*privs)
         raise DSLError, "to only allowed in has_permission_on blocks" if @current_rule.nil?
         @current_rule.append_privileges(privs.flatten)
       end
@@ -394,7 +394,7 @@ module Authorization
       #   if_attribute :type => "special"
       #   if_attribute :id   => [1,2]
       #
-      def if_attribute (attr_conditions_hash)
+      def if_attribute(attr_conditions_hash)
         raise DSLError, "if_attribute only in has_permission blocks" if @current_rule.nil?
         parse_attribute_conditions_hash!(attr_conditions_hash)
         @current_rule.append_attribute Attribute.new(attr_conditions_hash)
@@ -446,7 +446,7 @@ module Authorization
       #     if_permitted_to :read, :home_branch, :context => :branches
       #     if_permitted_to :read, :branch => :main_company, :context => :companies
       #
-      def if_permitted_to (privilege, attr_or_hash = nil, options = {})
+      def if_permitted_to(privilege, attr_or_hash = nil, options = {})
         raise DSLError, "if_permitted_to only in has_permission blocks" if @current_rule.nil?
         options[:context] ||= attr_or_hash.delete(:context) if attr_or_hash.is_a?(Hash)
         # only :context option in attr_or_hash:
@@ -458,25 +458,25 @@ module Authorization
       # In an if_attribute statement, is says that the value has to be
       # met exactly by the if_attribute attribute.  For information on the block
       # argument, see if_attribute.
-      def is (&block)
+      def is(&block)
         [:is, block]
       end
 
       # The negation of is.
-      def is_not (&block)
+      def is_not(&block)
         [:is_not, block]
       end
 
       # In an if_attribute statement, contains says that the value has to be
       # part of the collection specified by the if_attribute attribute.
       # For information on the block argument, see if_attribute.
-      def contains (&block)
+      def contains(&block)
         [:contains, block]
       end
 
       # The negation of contains.  Currently, query rewriting is disabled
       # for does_not_contain.
-      def does_not_contain (&block)
+      def does_not_contain(&block)
         [:does_not_contain, block]
       end
 
@@ -484,44 +484,44 @@ module Authorization
       # one of the values has to be part of the collection specified by the
       # if_attribute attribute.  The value block needs to evaluate to an
       # Enumerable.  For information on the block argument, see if_attribute.
-      def intersects_with (&block)
+      def intersects_with(&block)
         [:intersects_with, block]
       end
       
       # In an if_attribute statement, is_in says that the value has to
       # contain the attribute value.
       # For information on the block argument, see if_attribute.
-      def is_in (&block)
+      def is_in(&block)
         [:is_in, block]
       end
 
       # The negation of is_in.
-      def is_not_in (&block)
+      def is_not_in(&block)
         [:is_not_in, block]
       end
       
       # Less than
-      def lt (&block)
+      def lt(&block)
         [:lt, block]
       end
 
       # Less than or equal to
-      def lte (&block)
+      def lte(&block)
         [:lte, block]
       end
 
       # Greater than
-      def gt (&block)
+      def gt(&block)
         [:gt, block]
       end
 
       # Greater than or equal to
-      def gte (&block)
+      def gte(&block)
         [:gte, block]
       end
 
       private
-      def parse_attribute_conditions_hash! (hash)
+      def parse_attribute_conditions_hash!(hash)
         merge_hash = {}
         hash.each do |key, value|
           if value.is_a?(Hash)

--- a/lib/generators/authorization/install/install_generator.rb
+++ b/lib/generators/authorization/install/install_generator.rb
@@ -11,7 +11,7 @@ module Authorization
     class_option :commit, type: :boolean, default: false, desc: "Performs rake tasks such as migrate and seed."
     class_option :user_belongs_to_role, type: :boolean, default: false, desc: "Users have only one role, which can inherit others roles."
 
-    def self.next_migration_number dirname
+    def self.next_migration_number(dirname)
       if ActiveRecord::Base.timestamped_migrations
         Time.now.utc.strftime("%Y%m%d%H%M%S")
       else

--- a/test/controller_filter_resource_access_test.rb
+++ b/test/controller_filter_resource_access_test.rb
@@ -71,7 +71,7 @@ end
 
 
 class NestedResource < MockDataObject
-  def initialize (attributes = {})
+  def initialize(attributes = {})
     if attributes[:id]
       attributes[:parent_mock] ||= ParentMock.new(:id => attributes[:id])
     end
@@ -83,7 +83,7 @@ class NestedResource < MockDataObject
 end
 
 class ShallowNestedResource < MockDataObject
-  def initialize (attributes = {})
+  def initialize(attributes = {})
     if attributes[:id]
       attributes[:parent_mock] ||= ParentMock.new(:id => attributes[:id])
     end
@@ -97,10 +97,10 @@ end
 class ParentMock < MockDataObject
   def nested_resources
     Class.new do
-      def initialize (parent_mock)
+      def initialize(parent_mock)
         @parent_mock = parent_mock
       end
-      def new (attributes = {})
+      def new(attributes = {})
         NestedResource.new(attributes.merge(:parent_mock => @parent_mock))
       end
     end.new(self)
@@ -108,7 +108,7 @@ class ParentMock < MockDataObject
 
   alias :shallow_nested_resources :nested_resources
 
-  def == (other)
+  def ==(other)
     id == other.id
   end
   def self.name

--- a/test/development_support/analyzer_test.rb
+++ b/test/development_support/analyzer_test.rb
@@ -266,7 +266,7 @@ class AuthorizationRulesAnalyzerTest < Test::Unit::TestCase
   end
 
   protected
-  def engine_analyzer_for (rules)
+  def engine_analyzer_for(rules)
     reader = Authorization::Reader::DSLReader.new
     reader.parse rules
     engine = Authorization::Engine.new(reader)

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -99,7 +99,7 @@ class TestAttr < ActiveRecord::Base
   	  :test_model_id, :test_another_model_id
   end
 
-  def initialize (*args)
+  def initialize(*args)
     @role_symbols = []
     super(*args)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,7 +46,7 @@ rescue MissingSourceFile; end
 
 
 class MockDataObject
-  def initialize (attrs = {})
+  def initialize(attrs = {})
     attrs.each do |key, value|
       instance_variable_set(:"@#{key}", value)
       self.class.class_eval do
@@ -79,12 +79,12 @@ class MockDataObject
 end
 
 class MockUser < MockDataObject
-  def initialize (*roles)
+  def initialize(*roles)
     options = roles.last.is_a?(::Hash) ? roles.pop : {}
     super({:role_symbols => roles, :login => hash}.merge(options))
   end
 
-  def initialize_copy (other)
+  def initialize_copy(other)
     @role_symbols = @role_symbols.clone
   end
 end
@@ -97,7 +97,7 @@ class MocksController < ActionController::Base
     !!@authorized
   end
   
-  def self.define_action_methods (*methods)
+  def self.define_action_methods(*methods)
     methods.each do |method|
       define_method method do
         @authorized = true
@@ -110,7 +110,7 @@ class MocksController < ActionController::Base
     define_action_methods :index, :show, :edit, :update, :new, :create, :destroy
   end
   
-  def logger (*args)
+  def logger(*args)
     Class.new do 
       def warn(*args)
         #p args
@@ -176,7 +176,7 @@ if Rails.version < "4"
   class Test::Unit::TestCase
     include Authorization::TestHelper
     
-    def request! (user, action, reader, params = {})
+    def request!(user, action, reader, params = {})
       action = action.to_sym if action.is_a?(String)
       @controller.current_user = user
       @controller.authorization_engine = Authorization::Engine.new(reader)
@@ -203,7 +203,7 @@ elsif Rails.version < '4.1'
   class ActiveSupport::TestCase
     include Authorization::TestHelper
     
-    def request! (user, action, reader, params = {})
+    def request!(user, action, reader, params = {})
       action = action.to_sym if action.is_a?(String)
       @controller.current_user = user
       @controller.authorization_engine = Authorization::Engine.new(reader)
@@ -234,7 +234,7 @@ else
   class ActiveSupport::TestCase
     include Authorization::TestHelper
     
-    def request! (user, action, reader, params = {})
+    def request!(user, action, reader, params = {})
       action = action.to_sym if action.is_a?(String)
       @controller.current_user = user
       @controller.authorization_engine = Authorization::Engine.new(reader)


### PR DESCRIPTION
use parentheses around parameters in method definitions

`def each &block` is interpreted differently in ruby 2.2, than `def each(&block)` so I decided to go ahead and clean up all method declarations to be `def method_name(params)`  
