### PR TITLE
Don't explicitly support rails < 4.0.  or ruby <2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,12 @@
 language: ruby
 script: bundle exec rake test
 rvm:
-  - 1.8.7
-  - 1.9.3
+  - 2.0.0
+  - 2.1.9
 gemfile:
-  - gemfiles/2.3.gemfile
-  - gemfiles/3.0.gemfile
-  - gemfiles/3.1.gemfile
-  - gemfiles/3.2.gemfile
   - gemfiles/4.0.gemfile
   - gemfiles/4.1.gemfile
 matrix:
   exclude:
-    - rvm: 1.8.7
-      gemfile: gemfiles/4.0.gemfile
-    - rvm: 1.8.7
+    - rvm: 2.0.0
       gemfile: gemfiles/4.1.gemfile
-    - rvm: 1.9.3
-      gemfile: gemfiles/2.3.gemfile

--- a/declarative_authorization.gemspec
+++ b/declarative_authorization.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.name = "declarative_authorization"
   s.version = "1.0.0.pre"
 
-  s.required_ruby_version = ">= 1.8.6"
+  s.required_ruby_version = ">= 2.0.0"
   s.authors = ["Steffen Bartsch"]
   s.summary = "declarative_authorization is a Rails plugin for maintainable authorization based on readable authorization rules."
   s.email = "sbartsch@tzi.org"
@@ -12,6 +12,6 @@ Gem::Specification.new do |s|
   s.has_rdoc = true
   s.extra_rdoc_files = ['README.rdoc', 'CHANGELOG']
   s.homepage = %q{http://github.com/stffn/declarative_authorization}
-
-  #s.add_dependency('rails', '>= 2.1.0')
+  s.add_dependency('ruby_parser', '~> 3.6.6')
+  s.add_dependency('rails', '>= 4.0.0', '< 4.2.0')
 end

--- a/gemfiles/2.3.gemfile
+++ b/gemfiles/2.3.gemfile
@@ -1,8 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 2.3.0'
-gem 'sqlite3'
-gem 'ruby_parser'
-gem 'rdoc'
-gemspec :path => '..'
-

--- a/gemfiles/3.0.gemfile
+++ b/gemfiles/3.0.gemfile
@@ -1,8 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 3.0.0'
-gem 'sqlite3'
-gem 'ruby_parser'
-gem 'rdoc'
-gemspec :path => '..'
-

--- a/gemfiles/3.1.gemfile
+++ b/gemfiles/3.1.gemfile
@@ -1,8 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 3.1.0'
-gem 'sqlite3'
-gem 'ruby_parser'
-gem 'rdoc'
-gemspec :path => '..'
-

--- a/gemfiles/3.2.gemfile
+++ b/gemfiles/3.2.gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 3.2.0'
 gem 'sqlite3'
-gem 'ruby_parser'
 gem 'rdoc'
 gemspec :path => '..'
 

--- a/gemfiles/4.0.gemfile
+++ b/gemfiles/4.0.gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 4.0.0'
 gem 'sqlite3'
-gem 'ruby_parser'
 gem 'rdoc'
 gemspec :path => '..'
 

--- a/gemfiles/4.1.gemfile
+++ b/gemfiles/4.1.gemfile
@@ -2,6 +2,5 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 4.1.0'
 gem 'sqlite3'
-gem 'ruby_parser'
 gem 'rdoc'
 gemspec :path => '..'


### PR DESCRIPTION
use parentheses around parameters in method definitions

`def each &block` is interpreted differently in ruby 2.2, than `def each(&block)` so I decided to go ahead and clean up all method declarations to be `def method_name(params)`  
