### PR TITLE
Explicitly require action_controller

### DIFF
--- a/lib/declarative_authorization.rb
+++ b/lib/declarative_authorization.rb
@@ -13,6 +13,7 @@ end
 
 require File.join(%w{declarative_authorization railsengine}) if defined?(::Rails::Engine)
 
+require "action_controller"
 ActionController::Base.send :include, Authorization::AuthorizationInController
 ActionController::Base.helper Authorization::AuthorizationHelper
 


### PR DESCRIPTION
Without this `bundle console` will fail on a Gemfile such as this:

```ruby
source "https://rubygems.org"
gem "rails", "=4.2.7.1"
gem "declarative_authorization", github: "stffn/declarative_authorization"
```

I reproduced the bug on the following system:
Ubuntu 16.04 (within docker)
Rubygems 2.6.2
Bundler 1.13.6